### PR TITLE
[MASFRES-70] Use custom property name for local IT repo

### DIFF
--- a/source-release/pom.xml
+++ b/source-release/pom.xml
@@ -135,9 +135,11 @@ under the License.
                       <name>maven.home</name>
                       <value>${preparedMavenHome}</value>
                     </property>
+                    <!-- cannot use property "maven.repo.local" as already used as user property on the CLI through ASF Jenkins -->
+                    <!-- TODO: replace with "maven.repo.local" once https://issues.apache.org/jira/browse/SUREFIRE-1385 is fixed -->
                     <property>
                       <!-- Pass this through to the tests (if set!) to have them pick the right repository -->
-                      <name>maven.repo.local</name>
+                      <name>it.repo.local</name>
                       <value>${project.build.directory}/it-repo</value>
                     </property>
                   </systemProperties>

--- a/source-release/src/test/java/org/apache/its/IT_000_BasicArchiveCreation.java
+++ b/source-release/src/test/java/org/apache/its/IT_000_BasicArchiveCreation.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import static org.apache.its.util.TestUtils.archivePathFromChild;
 import static org.apache.its.util.TestUtils.archivePathFromProject;
 import static org.apache.its.util.TestUtils.assertZipContents;
+import static org.apache.its.util.TestUtils.createVerifier;
 import static org.apache.its.util.TestUtils.getTestDir;
 
 public class IT_000_BasicArchiveCreation {
@@ -44,8 +45,7 @@ public class IT_000_BasicArchiveCreation {
     public void execute() throws VerificationException, IOException, URISyntaxException {
         File testDir = getTestDir(BASENAME);
 
-        Verifier verifier = new Verifier(testDir.getAbsolutePath());
-
+        Verifier verifier = createVerifier(testDir);
         verifier.executeGoal("package");
 
         verifier.verifyErrorFreeLog();

--- a/source-release/src/test/java/org/apache/its/IT_001_ExcludeBuildOutputDirectory.java
+++ b/source-release/src/test/java/org/apache/its/IT_001_ExcludeBuildOutputDirectory.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 import static org.apache.its.util.TestUtils.archivePathFromChild;
 import static org.apache.its.util.TestUtils.archivePathFromProject;
 import static org.apache.its.util.TestUtils.assertZipContents;
+import static org.apache.its.util.TestUtils.createVerifier;
 import static org.apache.its.util.TestUtils.getTestDir;
 
 public class IT_001_ExcludeBuildOutputDirectory {
@@ -42,7 +43,7 @@ public class IT_001_ExcludeBuildOutputDirectory {
     public void execute() throws VerificationException, IOException, URISyntaxException {
         File testDir = getTestDir(BASENAME);
 
-        Verifier verifier = new Verifier(testDir.getAbsolutePath());
+        Verifier verifier = createVerifier(testDir);
 
         verifier.executeGoal("package");
 

--- a/source-release/src/test/java/org/apache/its/IT_002_IncludeSrcDirWithBuildOutputDirName.java
+++ b/source-release/src/test/java/org/apache/its/IT_002_IncludeSrcDirWithBuildOutputDirName.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 import static org.apache.its.util.TestUtils.archivePathFromChild;
 import static org.apache.its.util.TestUtils.archivePathFromProject;
 import static org.apache.its.util.TestUtils.assertZipContents;
+import static org.apache.its.util.TestUtils.createVerifier;
 import static org.apache.its.util.TestUtils.getTestDir;
 
 public class IT_002_IncludeSrcDirWithBuildOutputDirName {
@@ -42,7 +43,7 @@ public class IT_002_IncludeSrcDirWithBuildOutputDirName {
     public void execute() throws VerificationException, IOException, URISyntaxException {
         File testDir = getTestDir(BASENAME);
 
-        Verifier verifier = new Verifier(testDir.getAbsolutePath());
+        Verifier verifier = createVerifier(testDir);
 
         verifier.executeGoal("package");
 

--- a/source-release/src/test/java/org/apache/its/IT_003_SharedResourceInclusion.java
+++ b/source-release/src/test/java/org/apache/its/IT_003_SharedResourceInclusion.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 import static org.apache.its.util.TestUtils.archivePathFromChild;
 import static org.apache.its.util.TestUtils.archivePathFromProject;
 import static org.apache.its.util.TestUtils.assertZipContents;
+import static org.apache.its.util.TestUtils.createVerifier;
 import static org.apache.its.util.TestUtils.getTestDir;
 
 public class IT_003_SharedResourceInclusion {
@@ -42,7 +43,7 @@ public class IT_003_SharedResourceInclusion {
     public void execute() throws VerificationException, IOException, URISyntaxException {
         File testDir = getTestDir(BASENAME);
 
-        Verifier verifier = new Verifier(testDir.getAbsolutePath());
+        Verifier verifier = createVerifier(testDir);
 
         verifier.executeGoal("package");
 

--- a/source-release/src/test/java/org/apache/its/IT_004_IdeExcludes.java
+++ b/source-release/src/test/java/org/apache/its/IT_004_IdeExcludes.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import static org.apache.its.util.TestUtils.archivePathFromChild;
 import static org.apache.its.util.TestUtils.archivePathFromProject;
 import static org.apache.its.util.TestUtils.assertZipContents;
+import static org.apache.its.util.TestUtils.createVerifier;
 import static org.apache.its.util.TestUtils.getTestDir;
 
 public class IT_004_IdeExcludes {
@@ -43,7 +44,7 @@ public class IT_004_IdeExcludes {
     public void execute() throws VerificationException, IOException, URISyntaxException {
         File testDir = getTestDir(BASENAME);
 
-        Verifier verifier = new Verifier(testDir.getAbsolutePath());
+        Verifier verifier = createVerifier(testDir);
 
         verifier.executeGoal("package");
 

--- a/source-release/src/test/java/org/apache/its/IT_005_MiscellaneousExcludes.java
+++ b/source-release/src/test/java/org/apache/its/IT_005_MiscellaneousExcludes.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import static org.apache.its.util.TestUtils.archivePathFromChild;
 import static org.apache.its.util.TestUtils.archivePathFromProject;
 import static org.apache.its.util.TestUtils.assertZipContents;
+import static org.apache.its.util.TestUtils.createVerifier;
 import static org.apache.its.util.TestUtils.getTestDir;
 
 public class IT_005_MiscellaneousExcludes {
@@ -43,7 +44,7 @@ public class IT_005_MiscellaneousExcludes {
     public void execute() throws VerificationException, IOException, URISyntaxException {
         File testDir = getTestDir(BASENAME);
 
-        Verifier verifier = new Verifier(testDir.getAbsolutePath());
+        Verifier verifier = createVerifier(testDir);
 
         verifier.executeGoal("package");
 

--- a/source-release/src/test/java/org/apache/its/IT_006_CiExcludes.java
+++ b/source-release/src/test/java/org/apache/its/IT_006_CiExcludes.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 
 import static org.apache.its.util.TestUtils.archivePathFromProject;
 import static org.apache.its.util.TestUtils.assertZipContents;
+import static org.apache.its.util.TestUtils.createVerifier;
 import static org.apache.its.util.TestUtils.getTestDir;
 
 public class IT_006_CiExcludes {
@@ -42,7 +43,7 @@ public class IT_006_CiExcludes {
     public void execute() throws VerificationException, IOException, URISyntaxException {
         File testDir = getTestDir(BASENAME);
 
-        Verifier verifier = new Verifier(testDir.getAbsolutePath());
+        Verifier verifier = createVerifier(testDir);
 
         verifier.executeGoal("package");
 

--- a/source-release/src/test/java/org/apache/its/IT_ExcludeSrcDirWithinBuildOutputDir.java
+++ b/source-release/src/test/java/org/apache/its/IT_ExcludeSrcDirWithinBuildOutputDir.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 import static org.apache.its.util.TestUtils.archivePathFromChild;
 import static org.apache.its.util.TestUtils.archivePathFromProject;
 import static org.apache.its.util.TestUtils.assertZipContents;
+import static org.apache.its.util.TestUtils.createVerifier;
 import static org.apache.its.util.TestUtils.getTestDir;
 
 public class IT_ExcludeSrcDirWithinBuildOutputDir {
@@ -42,7 +43,7 @@ public class IT_ExcludeSrcDirWithinBuildOutputDir {
     public void execute() throws VerificationException, IOException, URISyntaxException {
         File testDir = getTestDir(BASENAME);
 
-        Verifier verifier = new Verifier(testDir.getAbsolutePath());
+        Verifier verifier = createVerifier(testDir);
 
         verifier.executeGoal("package");
 

--- a/source-release/src/test/java/org/apache/its/IT_IncludeIdeFilesWithinSrcDir.java
+++ b/source-release/src/test/java/org/apache/its/IT_IncludeIdeFilesWithinSrcDir.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 import static org.apache.its.util.TestUtils.archivePathFromChild;
 import static org.apache.its.util.TestUtils.archivePathFromProject;
 import static org.apache.its.util.TestUtils.assertZipContents;
+import static org.apache.its.util.TestUtils.createVerifier;
 import static org.apache.its.util.TestUtils.getTestDir;
 
 public class IT_IncludeIdeFilesWithinSrcDir {
@@ -42,7 +43,7 @@ public class IT_IncludeIdeFilesWithinSrcDir {
     public void execute() throws VerificationException, IOException, URISyntaxException {
         File testDir = getTestDir(BASENAME);
 
-        Verifier verifier = new Verifier(testDir.getAbsolutePath());
+        Verifier verifier = createVerifier(testDir);
 
         verifier.executeGoal("package");
 

--- a/source-release/src/test/java/org/apache/its/IT_ZipAndTarCreation.java
+++ b/source-release/src/test/java/org/apache/its/IT_ZipAndTarCreation.java
@@ -34,6 +34,7 @@ import static org.apache.its.util.TestUtils.archivePathFromChild;
 import static org.apache.its.util.TestUtils.archivePathFromProject;
 import static org.apache.its.util.TestUtils.assertTarContents;
 import static org.apache.its.util.TestUtils.assertZipContents;
+import static org.apache.its.util.TestUtils.createVerifier;
 import static org.apache.its.util.TestUtils.getTestDir;
 
 public class IT_ZipAndTarCreation {
@@ -45,7 +46,7 @@ public class IT_ZipAndTarCreation {
     public void execute() throws VerificationException, IOException, URISyntaxException {
         File testDir = getTestDir(BASENAME);
 
-        Verifier verifier = new Verifier(testDir.getAbsolutePath());
+        Verifier verifier = createVerifier(testDir);
 
         verifier.executeGoal("package");
 

--- a/source-release/src/test/java/org/apache/its/util/TestUtils.java
+++ b/source-release/src/test/java/org/apache/its/util/TestUtils.java
@@ -32,12 +32,27 @@ import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
 
 import org.apache.commons.compress.archivers.ArchiveEntry;
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.it.Verifier;
 import org.codehaus.plexus.archiver.tar.GZipTarFile;
 
 import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.fail;
 
 public class TestUtils {
+
+    private static final String IT_REPO_LOCAL = "it.repo.local";
+
+    public static Verifier createVerifier(File testDir) throws VerificationException {
+        Verifier verifier = new Verifier(testDir.getAbsolutePath());
+        // FIXME: remove using custom local repository instead of leveraging property "maven.repo.local" (workaround for
+        // https://issues.apache.org/jira/browse/SUREFIRE-1385)
+        String itRepoLocal = System.getProperty(IT_REPO_LOCAL);
+        if (itRepoLocal != null) {
+            verifier.setLocalRepo(itRepoLocal);
+        }
+        return verifier;
+    }
 
     public static String archivePathFromChild(String artifactId, String version, String childName, String childPath) {
         if (!childPath.startsWith("/")) {


### PR DESCRIPTION
Cannot use standard "maven.repo.local" because it is used by ASF Jenkins already and cannot be overwritten
(https://issues.apache.org/jira/browse/SUREFIRE-1385)